### PR TITLE
Use pip3, pre-commit v2.13.0 and split RUN

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,20 @@
 FROM debian:stable-slim
 
-ENV PRE_COMMIT_VERSION 1.5.1
+ENV PRE_COMMIT_VERSION 2.13.0
+
+WORKDIR /pre-commit
+
 RUN apt-get update && apt-get install -y \
       build-essential \
       git \
-      python-pip \
-      python3 && \
-      pip install pre-commit==${PRE_COMMIT_VERSION} \
-      && mkdir /pre-commit && \
-      cd /pre-commit && \
-      git init . && \
-      pre-commit install
+      python3-pip \
+      python3 \
+      && rm -rf /var/lib/apt/lists/*
+      
+RUN git init .
 
-WORKDIR /pre-commit
+RUN pip3 install pre-commit==${PRE_COMMIT_VERSION} && \      
+      pre-commit install
 
 CMD ["pre-commit", "run", "--all-files"]
 


### PR DESCRIPTION
pre-commit is now at v2.13.0 and requires Python 3. Install the `python3-pip` package for that and use `pip3`.
Also split the one `RUN` command into separate ones, so that an update of pre-commit doesn't require a rebuild of everything.